### PR TITLE
feature: enabling the possibilite of filter using min and max skill

### DIFF
--- a/src/modules/BazaarAuctions/components/FilterDrawer/index.tsx
+++ b/src/modules/BazaarAuctions/components/FilterDrawer/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/accessible-emoji */
 import { useTranslations } from 'contexts/useTranslation'
 import { memo, useRef, useCallback } from 'react'
-import { Drawer, Chip, RangeSliderInput, SliderInput } from 'components/Atoms'
+import { Drawer, Chip, RangeSliderInput } from 'components/Atoms'
 import { Tooltip } from 'components/Organisms'
 import { useDrawerFields } from '../../contexts/useDrawerFields'
 import { useFilters } from '../../contexts/useFilters'
@@ -237,17 +237,19 @@ const FilterDrawer = ({
         </FilterGroup>
 
         <FilterGroup label="Skill">
-          <SliderInput
+          <S.RangeSliderInput
             aria-label={homepage.FilterDrawer.minSkillLabel}
             min={10}
-            max={130}
-            value={filterState.minSkill}
+            max={150}
+            value={[filterState.minSkill, filterState.maxSkill]}
             onChange={useCallback(
-              (event: React.ChangeEvent<HTMLInputElement>) =>
-                updateFilters('minSkill', parseInt(event.target.value, 10)),
+              (values: [number, number]) => {
+                const [newMin, newMax] = values
+                updateFilters('minSkill', newMin)
+                updateFilters('maxSkill', newMax)
+              },
               [updateFilters],
             )}
-            style={{ marginBottom: 16 }}
           />
           <S.ChipWrapper>
             <S.IconChip

--- a/src/modules/BazaarAuctions/components/FilterDrawer/styles.ts
+++ b/src/modules/BazaarAuctions/components/FilterDrawer/styles.ts
@@ -3,6 +3,7 @@ import {
   DrawerFooter as BaseDrawerFooter,
   Input as BaseInput,
   Chip as BaseChip,
+  RangeSliderInput as BaseRangeSliderInput,
 } from 'components/Atoms'
 import { AutocompleteInput as BaseAutocompleteInput } from 'components/Organisms'
 import { Smooth } from 'styles'
@@ -96,4 +97,8 @@ export const ResetButton = styled.button`
   &:active {
     box-shadow: inset 2px 2px rgba(0, 0, 0, 0.14);
   }
+`
+
+export const RangeSliderInput = styled(BaseRangeSliderInput)`
+  margin-bottom: 16px;
 `

--- a/src/modules/BazaarAuctions/contexts/useFilters/schema.ts
+++ b/src/modules/BazaarAuctions/contexts/useFilters/schema.ts
@@ -68,6 +68,10 @@ export const filterSchema = [
     key: 'minSkill',
     defaultValue: 10,
   },
+  {
+    key: 'maxSkill',
+    defaultValue: 150,
+  },
 
   {
     key: 'skillKey',

--- a/src/services/Auctions/defaults.ts
+++ b/src/services/Auctions/defaults.ts
@@ -20,6 +20,7 @@ export const DEFAULT_FILTER_STATE: FilterState = {
   minLevel: 8,
   maxLevel: 2000,
   minSkill: 10,
+  maxSkill: 150,
   skillKey: new Set([]),
   imbuementsSet: new Set([]),
   itemSet: new Set([]),

--- a/src/types/FilterState.d.ts
+++ b/src/types/FilterState.d.ts
@@ -13,6 +13,7 @@ declare interface FilterState {
   minLevel: number
   maxLevel: number
   minSkill: number
+  maxSkill: number
   skillKey: Set<ImbuementOptions>
   imbuementsSet: Set<string>
   itemSet: Set<string>
@@ -26,6 +27,7 @@ type FilterOptionsPrimitives = Pick<
   | 'minLevel'
   | 'maxLevel'
   | 'minSkill'
+  | 'maxSkill'
   | 'rareNick'
   | 'soulwarFilter'
 >


### PR DESCRIPTION
I was looking for a char in the auction feature to purchase a character between ml 80 and 90 using the [exevopan.com](https://www.exevopan.com/) and I realized that it was not possible.

- tried to follow all code standards
- I didn't find access to change the filter API, but I believe that this PR can help the implementation.

@xandjiji congrats for the amazing work =)



