### PR TITLE
fix: z-index auctions grid

### DIFF
--- a/apps/exevo-pan/src/components/Atoms/Popover/index.tsx
+++ b/apps/exevo-pan/src/components/Atoms/Popover/index.tsx
@@ -119,7 +119,7 @@ const Popover = ({
           style={styles.popper}
           {...attributes.popper}
           className={clsx(
-            'z-51 animate-fadeIn',
+            'z-71 animate-fadeIn',
             className,
             attributes.popper?.className,
           )}

--- a/apps/exevo-pan/src/modules/BazaarAuctions/components/AuctionsGrid/index.tsx
+++ b/apps/exevo-pan/src/modules/BazaarAuctions/components/AuctionsGrid/index.tsx
@@ -65,7 +65,7 @@ const AuctionsGrid = () => {
     <main>
       <div
         id="grid-header"
-        className="z-71 bg-surface inner-container sticky top-0 flex h-[70px] w-full select-none items-end gap-2 py-2 shadow-md md:items-center"
+        className="z-51 bg-surface inner-container sticky top-0 flex h-[70px] w-full select-none items-end gap-2 py-2 shadow-md md:items-center"
       >
         <S.Button
           tabIndex={0}

--- a/apps/exevo-pan/src/modules/BazaarAuctions/components/AuctionsGrid/index.tsx
+++ b/apps/exevo-pan/src/modules/BazaarAuctions/components/AuctionsGrid/index.tsx
@@ -65,7 +65,7 @@ const AuctionsGrid = () => {
     <main>
       <div
         id="grid-header"
-        className="z-51 bg-surface inner-container sticky top-0 flex h-[70px] w-full select-none items-end gap-2 py-2 shadow-md md:items-center"
+        className="z-71 bg-surface inner-container sticky top-0 flex h-[70px] w-full select-none items-end gap-2 py-2 shadow-md md:items-center"
       >
         <S.Button
           tabIndex={0}


### PR DESCRIPTION
Fixes grid header z-index hierarchy to avoid conflicts with layout of other components.
* Fixes issue #191



![image](https://github.com/xandjiji/exevo-pan/assets/82242011/aa7f5033-aaa5-43aa-8a65-59e68120cb59)

Edit: I was wrong, I realized that the intention was always to leave the grid-header superimposed when using the sticky effect, I made the necessary changes only in the Popover of character details now, I hope this adjustment helps. xD
