### PR TITLE
fix: imbuements cost page heading title

### DIFF
--- a/apps/exevo-pan/src/pages/calculators/imbuements-cost.tsx
+++ b/apps/exevo-pan/src/pages/calculators/imbuements-cost.tsx
@@ -7,7 +7,7 @@ import { buildUrl, buildPageTitle, loadRawSrc } from 'utils'
 import { routes, jsonld } from 'Constants'
 import { common, calculators } from 'locales'
 
-const pageRoute = routes.EXERCISE_WEAPONS
+const pageRoute = routes.IMBUEMENTS_COST
 const pageUrl = buildUrl(pageRoute)
 
 export default function Calculator() {


### PR DESCRIPTION
Just a small fix to set the correct heading title to the Imbuements Cost page