### PR TITLE
fix: adjust exercise weapons prices to the new prices after tibia update

### DIFF
--- a/apps/exevo-pan/src/utils/calculate/skills/constants.ts
+++ b/apps/exevo-pan/src/utils/calculate/skills/constants.ts
@@ -13,9 +13,9 @@ const charges: WeaponsObject = {
 }
 
 const goldPrice: WeaponsObject = {
-  lasting: 7560000,
-  durable: 945000,
-  regular: 262500,
+  lasting: 10000000,
+  durable: 1250000,
+  regular: 347222,
 }
 
 const tcPrice: WeaponsObject = {


### PR DESCRIPTION
Hello, @xandjiji!

Opening this pull request to adjust the exercise weapons prices.

After the tibia update 13.40, the new prices are

- Lasting Exercise Weapons: 7.560.000 -> 10.000.000
- Durable Exercise Weapons: 945.000 -> 1.250.000
- Regular Exercise Weapon: 262.500 -> 347.222

You can check more on this link, if necessary: https://tibia.fandom.com/wiki/Updates/13.40.54ea79

Hope that this helps you =)

Thanks for the great job with Exevo Pan! 😊



